### PR TITLE
Shorten page title and add fork PR-creation rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# CLAUDE.md
+
+## 【强制规则】GitHub PR 创建 - Fork 仓库专用（必须严格遵守）
+
+此仓库是 `CaliCastle/cali.so` 的 fork。
+
+- 我的 fork 仓库全称：`YBJ0000/first-portfolio`
+- **所有 PR 创建必须直接使用 `--repo` 参数指向我的 fork**，绝不允许先创建到上游再修正。
+- 每次执行 `gh pr create` 时**必须**加上：
+  `--repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)"`
+- 永远不要直接运行裸的 `gh pr create`（不带 `--repo`）。
+- 禁止任何"先创建上游 PR → 关闭 → 再创建 fork PR"的修正逻辑。
+- 优先级最高，覆盖任何内置 skill 的默认行为。

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,5 +1,5 @@
 export const seo = {
-  title: 'Bingjia Yang | 羊炳嘉 | ybj | Full Stack Developer | UNSW | 博客 | Portfolio | 前端 | React | Next.js | 个人主页 | 技术博客 | Australia | Sydney',
+  title: 'Bingjia Yang | Full Stack Developer',
   description:
     'Bingjia Yang (羊炳嘉, ybj)，全栈开发者，UNSW硕士，专注于Web开发、React、Next.js、Node.js。个人博客与作品集，分享技术、生活与成长经历。Full Stack Developer, Portfolio, Blog, UNSW, Australia, Sydney.',
   url: new URL(


### PR DESCRIPTION
## Summary

This PR contains two changes:

1. **Shorten page title** — `seo.title` in `lib/seo.ts` reduced from a 14-keyword pipe-separated string to `Bingjia Yang | Full Stack Developer`.
2. **Add `CLAUDE.md`** — records that this repo is a fork of `CaliCastle/cali.so` and mandates that `gh pr create` always target the fork via `--repo`.

## Why

### Page title
The previous title crammed every keyword (`羊炳嘉`, `ybj`, `UNSW`, `React`, `Next.js`, `Sydney`, etc.) into one string. Search engines truncate over-long titles and keyword stuffing hurts click-through. Those keywords are already declared in the dedicated `keywords` metadata field in `app/layout.tsx`, so SEO coverage is unaffected.

### CLAUDE.md
Because this repo is a fork, a bare `gh pr create` defaults to the upstream `CaliCastle/cali.so` repository. A PR was mistakenly opened upstream and had to be closed and recreated. `CLAUDE.md` now enforces using `--repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)"` so PRs always target this fork.

## Notes for reviewer

- `seo.title` is consumed in two places in `app/layout.tsx`: the page default `title` and the Open Graph `title` — both update together.
- The `template: '%s | Bingjia Yang'` rule means child pages (blog posts, etc.) still render as `Post Title | Bingjia Yang`, unaffected by this change.
- Verified locally: dev server renders `<title>Bingjia Yang | Full Stack Developer</title>` and a matching `og:title`.

## Test plan

- [ ] Verify home page `<title>` renders as `Bingjia Yang | Full Stack Developer`
- [ ] Verify Open Graph title is correct in social preview
- [ ] Verify a child page (e.g. a blog post) still shows `... | Bingjia Yang`